### PR TITLE
Fix temp dir permission docker error

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ omit =
     skift/scripts/*
     skift/_version.py
     */__init__.py
+    venv/*
 [report]
 show_missing = True
 # Regexes for lines to exclude from consideration

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,16 @@ Additionally, the official Python bindings prevent the ``pretrainedVectors`` arg
 
   pip install git+https://github.com/shaypal5/fastText.git@fdbc22b18c44fd223da844f10afdfbaa3e956219
 
+Temporary Storage Location - SKIFT_TEMP_DIR:
+
+Skift uses temporary storage on the filesystem.  By default, this storage is allocated in the system temporary storage location (i.e. /tmp on *nix systems).  To override the temp location, use the SKIFT_TEMP_DIR environment variable:
+
+.. code-block:: bash
+
+  export SKIFT_TEMP_DIR=/path/to/desired/temp/folder
+
+**NOTE:** The directory will be created if it does not exist
+
 
 Features
 ========

--- a/skift/util.py
+++ b/skift/util.py
@@ -5,14 +5,19 @@ from random import randint
 
 from fastText import load_model
 
+# Only create the temp directory if it is needed
+TEMP_DIR = None
 
-TEMP_DIR = os.path.expanduser('~/.temp')
-os.makedirs(TEMP_DIR, exist_ok=True)
-
+def get_temp_dir_name():
+    # Create the temp dir if it doesn't exist
+    if not TEMP_DIR:
+        import tempfile
+        TEMP_DIR = tempfile.mkdtemp()
+    return TEMP_DIR
 
 def temp_dataset_fpath():
     temp_fname = 'temp_ft_trainset_{}.ft'.format(randint(1, 99999))
-    return os.path.join(TEMP_DIR, temp_fname)
+    return os.path.join(get_temp_dir_name(), temp_fname)
 
 
 # def dump_df_to_fasttext_format(df, filepath, label_field, text_field):
@@ -54,7 +59,7 @@ def dump_xy_to_fasttext_format(X, y, filepath):
 
 def temp_model_fpath():
     temp_fname = 'temp_ft_model_{}.ft'.format(randint(1, 99999))
-    return os.path.join(TEMP_DIR, temp_fname)
+    return os.path.join(get_temp_dir_name(), temp_fname)
 
 
 def python_fasttext_model_to_bytes(model):

--- a/skift/util.py
+++ b/skift/util.py
@@ -7,10 +7,21 @@ from fastText import load_model
 
 
 def get_temp_dir_name():
+    """
+    Get the temp directory name from the SKIFT_TEMP_DIR environment variable, or
+    create the directory in the system temp folder
+
+    :return:
+    """
     # Create a static variable/singleton for the temp directory name
     if 'dir_name' not in get_temp_dir_name.__dict__:
-        import tempfile
-        get_temp_dir_name.dir_name = tempfile.mkdtemp()
+        env_name = os.getenv("SKIFT_TEMP_DIR", False)
+        if env_name:
+            os.makedirs(env_name, exist_ok=True)
+            get_temp_dir_name.dir_name = env_name
+        else:
+            import tempfile
+            get_temp_dir_name.dir_name = tempfile.mkdtemp()
     return get_temp_dir_name.dir_name
 
 def temp_dataset_fpath():

--- a/skift/util.py
+++ b/skift/util.py
@@ -5,6 +5,8 @@ from random import randint
 
 from fastText import load_model
 
+SKIFT_TEMP_DIR_ENV_VAR = "SKIFT_TEMP_DIR"
+
 
 def get_temp_dir_name():
     """
@@ -14,8 +16,9 @@ def get_temp_dir_name():
     :return:
     """
     # Create a static variable/singleton for the temp directory name
-    if 'dir_name' not in get_temp_dir_name.__dict__:
-        env_name = os.getenv("SKIFT_TEMP_DIR", False)
+    if 'dir_name' not in get_temp_dir_name.__dict__ or \
+            not os.path.isdir(get_temp_dir_name.dir_name):
+        env_name = os.getenv(SKIFT_TEMP_DIR_ENV_VAR, False)
         if env_name:
             os.makedirs(env_name, exist_ok=True)
             get_temp_dir_name.dir_name = env_name
@@ -23,6 +26,7 @@ def get_temp_dir_name():
             import tempfile
             get_temp_dir_name.dir_name = tempfile.mkdtemp()
     return get_temp_dir_name.dir_name
+
 
 def temp_dataset_fpath():
     temp_fname = 'temp_ft_trainset_{}.ft'.format(randint(1, 99999))

--- a/skift/util.py
+++ b/skift/util.py
@@ -5,15 +5,13 @@ from random import randint
 
 from fastText import load_model
 
-# Only create the temp directory if it is needed
-TEMP_DIR = None
 
 def get_temp_dir_name():
-    # Create the temp dir if it doesn't exist
-    if not TEMP_DIR:
+    # Create a static variable/singleton for the temp directory name
+    if 'dir_name' not in get_temp_dir_name.__dict__:
         import tempfile
-        TEMP_DIR = tempfile.mkdtemp()
-    return TEMP_DIR
+        get_temp_dir_name.dir_name = tempfile.mkdtemp()
+    return get_temp_dir_name.dir_name
 
 def temp_dataset_fpath():
     temp_fname = 'temp_ft_trainset_{}.ft'.format(randint(1, 99999))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -132,3 +132,52 @@ def test_cross_val():
     ftdf = _big_ftdf()
     cross_val_score(
         ft_clf, X=ftdf[['txt']], y=ftdf['lbl'], cv=2, scoring='accuracy')
+
+
+def test_get_temp_dir_from_tempfile():
+    from skift.util import get_temp_dir_name, SKIFT_TEMP_DIR_ENV_VAR
+    import os
+    import shutil
+
+    try:
+        # Clear the Skift temp dir environment variable to prepare for the test
+        env_var = os.environ[SKIFT_TEMP_DIR_ENV_VAR]
+        del os.environ[SKIFT_TEMP_DIR_ENV_VAR]
+    except KeyError:
+        env_var = None
+
+    tempdir = get_temp_dir_name()
+    assert os.path.isdir(tempdir)
+
+    if env_var:
+        os.environ[SKIFT_TEMP_DIR_ENV_VAR] = env_var
+
+    shutil.rmtree(tempdir)
+
+
+def test_get_temp_dir_environment():
+    from skift.util import get_temp_dir_name, SKIFT_TEMP_DIR_ENV_VAR
+    import os
+    import shutil
+    import tempfile
+
+    try:
+        # Save the existing Skift temp dir env var
+        env_var = os.environ[SKIFT_TEMP_DIR_ENV_VAR]
+        del os.environ[SKIFT_TEMP_DIR_ENV_VAR]
+    except KeyError:
+        env_var = None
+
+    # Create a temporary directory for the test
+    test_tempdir = tempfile.mkdtemp()
+    os.environ[SKIFT_TEMP_DIR_ENV_VAR] = test_tempdir
+
+    # Should use the temp dir from the environment variable
+    assert test_tempdir == get_temp_dir_name()
+
+    if env_var:
+        os.environ[SKIFT_TEMP_DIR_ENV_VAR] = env_var
+    else:
+        del os.environ[SKIFT_TEMP_DIR_ENV_VAR]
+
+    shutil.rmtree(test_tempdir)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -5,6 +5,8 @@ import pickle
 
 import pytest
 import pandas as pd
+import tempfile
+
 from sklearn.exceptions import NotFittedError
 
 from skift import FirstColFtClassifier
@@ -24,7 +26,7 @@ def test_pickle():
     assert ft_clf.predict([['woof lol']])[0] == 0
     assert ft_clf.predict([['meow lolz']])[0] == 1
 
-    pic_fpath = os.path.expanduser('~/.temp/ttemp_ft_model.ft')
+    fd, pic_fpath = tempfile.mkstemp()
     with open(pic_fpath, 'wb+') as bfile:
         pickle.dump(ft_clf, bfile)
     with open(pic_fpath, 'rb') as bfile:
@@ -37,6 +39,10 @@ def test_pickle():
     assert ft_clf2.predict([['woof lol']])[0] == 0
     assert ft_clf2.predict([['meow lolz']])[0] == 1
 
+    # Clean up
+    os.close(fd)    # Prevent a file-handle leak
+    os.unlink(pic_fpath)
+
 
 def test_pickle_unfitted():
     ftdf = pd.DataFrame(
@@ -45,7 +51,8 @@ def test_pickle_unfitted():
     )
     ft_clf = FirstColFtClassifier()
 
-    pic_fpath = os.path.expanduser('~/.temp/ttemp_ft_model.ft')
+    fd, pic_fpath = tempfile.mkstemp()
+
     with open(pic_fpath, 'wb+') as bfile:
         pickle.dump(ft_clf, bfile)
     with open(pic_fpath, 'rb') as bfile:
@@ -71,3 +78,7 @@ def test_pickle_unfitted():
     assert ft_clf2.predict([['meow']])[0] == 1
     assert ft_clf2.predict([['woof lol']])[0] == 0
     assert ft_clf2.predict([['meow lolz']])[0] == 1
+
+    # Clean up
+    os.close(fd)    # Prevent a file-handle leak
+    os.unlink(pic_fpath)


### PR DESCRIPTION
- Remove dependance on user home directory for temporary storage.  User directories ("~/") are not always created for Unix service accounts.
- Create the temporary directory using tempfile.mkdtemp()
- Store the directory path in a singleton-like structure accessed via a function call

This fixes issue https://github.com/shaypal5/skift/issues/6 by creating the tempdir in an OS/environment agnostic way, and does not rely on the users' home directory being writeable.  

