### PR TITLE
utf-8 encoding for xy input file

### DIFF
--- a/skift/util.py
+++ b/skift/util.py
@@ -65,7 +65,7 @@ def dump_xy_to_fasttext_format(X, y, filepath):
     filepath : str
         The fully qualified path to the file to dump.
     """
-    with open(filepath, 'w+') as wfile:
+    with open(filepath, 'w+', encoding='utf-8') as wfile:
         for text, label in zip(X, y):
             wfile.write('__label__{} {}\n'.format(label, text))
 


### PR DESCRIPTION
fastText assumes UTF-8 encoded text (see fastText Python README).

Without the `encoding` flag, the xy input file is written using the system's locale, which is problematic, especially on Windows. Attempting to train a model with text which uses utf-8 symbols results in an exception.

Passing the flag to `open` when writing the input file solves this issue.